### PR TITLE
Revert "Bump Bitwarden client versions to v2024.4.0"

### DIFF
--- a/Bitwarden.SecureSync.Logic/Client/BitwardenClientDownloadLogic.cs
+++ b/Bitwarden.SecureSync.Logic/Client/BitwardenClientDownloadLogic.cs
@@ -6,18 +6,18 @@ namespace Bitwarden.SecureSync.Logic.Client;
 
 public class BitwardenClientDownloadLogic : IBitwardenClientDownloadLogic
 {
-    private const string CLIENT_VERSION_WINDOWS = "v2024.4.0";
-    private const string CLIENT_VERSION_OSX = "v2024.4.0";
-    private const string CLIENT_VERSION_LINUX = "v2024.4.0";
+    private const string CLIENT_VERSION_WINDOWS = "v2024.2.1";
+    private const string CLIENT_VERSION_OSX = "v2024.3.1";
+    private const string CLIENT_VERSION_LINUX = "v2024.3.1";
 
     private const string WINDOWS_CLIENT_URL =
-        "https://github.com/bitwarden/clients/releases/download/cli-v2024.4.0/bw-windows-2024.4.0.zip";
+        "https://github.com/bitwarden/clients/releases/download/cli-v2024.2.1/bw-windows-2024.2.1.zip";
 
     private const string LINUX_CLIENT_URL =
-        "https://github.com/bitwarden/clients/releases/download/cli-v2024.4.0/bw-linux-2024.4.0.zip";
+        "https://github.com/bitwarden/clients/releases/download/cli-v2024.3.1/bw-linux-2024.3.1.zip";
 
     private const string OSX_CLIENT_URL =
-        "https://github.com/bitwarden/clients/releases/download/cli-v2024.4.0/bw-macos-2024.4.0.zip";
+        "https://github.com/bitwarden/clients/releases/download/cli-v2024.3.1/bw-macos-2024.3.1.zip";
 
     private readonly DirectoryInfo _clientDownloadDirectory;
     private readonly FileInfo _clientFile;


### PR DESCRIPTION
2024.4.0 introduces a new (undocumented) input requirement after starting the export command, causing the application to hang. Rolling back the update for now.