### PR TITLE
Bump OSX/Linux clients to v2024.7.2, update docker entrypoint

### DIFF
--- a/Bitwarden.SecureSync.Logic/Client/BitwardenClientDownloadLogic.cs
+++ b/Bitwarden.SecureSync.Logic/Client/BitwardenClientDownloadLogic.cs
@@ -7,17 +7,17 @@ namespace Bitwarden.SecureSync.Logic.Client;
 public class BitwardenClientDownloadLogic : IBitwardenClientDownloadLogic
 {
     private const string CLIENT_VERSION_WINDOWS = "v2024.2.1";
-    private const string CLIENT_VERSION_OSX = "v2024.3.1";
-    private const string CLIENT_VERSION_LINUX = "v2024.3.1";
+    private const string CLIENT_VERSION_OSX = "v2024.7.2";
+    private const string CLIENT_VERSION_LINUX = "v2024.7.2";
 
     private const string WINDOWS_CLIENT_URL =
         "https://github.com/bitwarden/clients/releases/download/cli-v2024.2.1/bw-windows-2024.2.1.zip";
 
     private const string LINUX_CLIENT_URL =
-        "https://github.com/bitwarden/clients/releases/download/cli-v2024.3.1/bw-linux-2024.3.1.zip";
+        "https://github.com/bitwarden/clients/releases/download/cli-v2024.7.2/bw-linux-2024.7.2.zip";
 
     private const string OSX_CLIENT_URL =
-        "https://github.com/bitwarden/clients/releases/download/cli-v2024.3.1/bw-macos-2024.3.1.zip";
+        "https://github.com/bitwarden/clients/releases/download/cli-v2024.7.2/bw-macos-2024.7.2.zip";
 
     private readonly DirectoryInfo _clientDownloadDirectory;
     private readonly FileInfo _clientFile;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+mkdir /.cache && chmod -R 777 /.cache
+chown -R ${PUID}:${PGID} /.cache
+
 mkdir /.config && mkdir /.config/Bitwarden\ CLI
 chown -R ${PUID}:${PGID} /.config/Bitwarden\ CLI
 


### PR DESCRIPTION
- Bump OSX/Linux clients to v2024.7.2
- Update docker entrypoint in order to resolve possible permission issues with Bitwarden .cache directory
